### PR TITLE
Rebuild if AVR_CPU_FREQUENCY_HZ environment variable changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
+/.vscode
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avr-config"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Dylan McKay <me@dylanmckay.io>"]
 edition = "2018"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(feature = "cpu-frequency")]
+    println!("cargo:rerun-if-env-changed=AVR_CPU_FREQUENCY_HZ");
+}


### PR DESCRIPTION
Add build script to rebuild if AVR_CPU_FREQUENCY_HZ environment variable changes. Fixes https://github.com/avr-rust/avr-config/issues/3